### PR TITLE
Support transparency, Add configurable padding, Add helper module and spritesheet config export, Add anti-aliasing

### DIFF
--- a/ConfigReader.lua
+++ b/ConfigReader.lua
@@ -3,7 +3,7 @@ local floor, sqrt = math.floor, math.sqrt ;
 --[[ Returns ImageRectOffset (top left of sprite) starting from 0 as x, y ]]--
 function GetOffset( config, number )
 	local intRows = sqrt( config.count ) ;
-	number = number % config.count ;
+	number = floor(number) % config.count ;
 	return ( ( config.diameter + config.padding * 2 ) * ( floor( number % intRows ) ) ) + config.padding, ( ( config.diameter + config.padding * 2 ) * floor( number / intRows ) ) + config.padding  ;
 end
 

--- a/ConfigReader.lua
+++ b/ConfigReader.lua
@@ -1,0 +1,18 @@
+local floor, sqrt = math.floor, math.sqrt ;
+
+--[[ Returns ImageRectOffset (top left of sprite) starting from 0 as x, y ]]--
+function GetOffset( config, number )
+	local intRows = sqrt( config.count ) ;
+	number = number % config.count ;
+	return ( ( config.diameter + config.padding * 2 ) * ( floor( number % intRows ) ) ) + config.padding, ( ( config.diameter + config.padding * 2 ) * floor( number / intRows ) ) + config.padding  ;
+end
+
+--[[ Returns ImageRectSize (size of sprite) as x, y ]]--
+function GetSize( config )
+	return config.diameter, config.diameter
+end
+
+return {
+	GetOffset = GetOffset,
+	GetSize = GetSize
+} ;

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Inside the *love.load( )* function you will be able to find some parameters you 
 
 
 ### **Notes**
-The images still need some sort of editing before they are able to be used in a game due to their "black background". You can do this on various ways, one of my ways is by opening the generated image in eg Paint.Net then use the Magic Wand to select the black and then remove it. However, this method is not the best when using images as a shape as it will leave a black tray around the image, this can be combated by possibly setting *rgbaBg* to another RGB colour that matches eg the colour of the loading screen that will be used. For just polygons this can be combated by using Hue/Saturation in Paint.Net with lightness on 100. (Adjustments>Adjust Hue/Saturation; or Ctrl+Shift+U).
+This supports transparent backgrounds and transparent images. The generated images will have transparent background, and image transparency will show.
 
 The end result will stay "pixelated" because we are limited to 1024x1024 images on ROBLOX, there is nothing I can do about that.
 
@@ -29,7 +29,7 @@ The end result will stay "pixelated" because we are limited to 1024x1024 images 
 *The following examples are using an image with the dimension of **1024x1024**, most images that are bigger than this will be down scaled to this.*
 
 ### ROBLOX Example (Polygonal)
-	
+
 ```lua    
 --[[ Insert this in a localscript in an ImageLabel/ImageButton ]]--
 --[[ Touch this ]]--
@@ -47,7 +47,7 @@ local floor						=	math.floor ;
 script.Parent.ImageRectSize		=	vec2New( intBox, intBox ) ;
 
 while ( wait( .1 ) ) do
-script.Parent.ImageRectOffset=	vec2New( intOffset + ( ( intCurrent % intShapesPerRow ) * intBoxOffset ), intOffset + ( floor( intCurrent / intImagesPerRow ) * intBoxOffset ) ) ; 
+script.Parent.ImageRectOffset=	vec2New( intOffset + ( ( intCurrent % intShapesPerRow ) * intBoxOffset ), intOffset + ( floor( intCurrent / intImagesPerRow ) * intBoxOffset ) ) ;
 intCurrent 					=	( intCurrent >= intShapes ) and 0 or intCurrent + 1 ;
 end
 ```
@@ -72,7 +72,7 @@ local floor						=	math.floor ;
 script.Parent.ImageRectSize		=	vec2New( intBox, intBox ) ;
 
 while ( wait( .1 ) ) do
-script.Parent.ImageRectOffset=	vec2New( intOffset + ( ( intCurrent % intShapesPerRow ) * intBoxOffset ), intOffset + ( floor( intCurrent / intImagesPerRow ) * intBoxOffset ) ) ; 
+script.Parent.ImageRectOffset=	vec2New( intOffset + ( ( intCurrent % intShapesPerRow ) * intBoxOffset ), intOffset + ( floor( intCurrent / intImagesPerRow ) * intBoxOffset ) ) ;
 intCurrent 					=	( intCurrent >= intShapes ) and 0 or intCurrent + 1 ;
 end
 ```

--- a/README.md
+++ b/README.md
@@ -6,74 +6,48 @@ LovelySpritesheet is a polygonal/Image "progress bar spritesheet" like generator
 
 ----------
 ### Usage
-The usage is fairly simple, download the latest [Love2D](https://love2d.org/), extract the downloaded ZIP somewhere in a folder (eg 'Love2D' on your Desktop), create a shortcut on eg your Desktop to Desktop/love.exe. After this you need to download this repository, put this in a folder on eg your Desktop and then drag the folder onto the shortcut to Desktop/love.exe. Now check your %APPDATA%/LOVE/CircleSpritesheet (on Windows) for the generated sprite sheet.
+The usage is fairly simple, download the latest [Love2D](https://love2d.org/), extract the downloaded ZIP somewhere in a folder (eg 'Love2D' on your Desktop), create a shortcut on eg your Desktop to Desktop/love.exe. After this you need to download this repository, put this in a folder on eg your Desktop and then drag the folder onto the shortcut to Desktop/love.exe. Now check  `%APPDATA%/LOVE/CircleSpritesheet` in File Explorer (on Windows) for the generated sprite sheet image, lua sprite sheet info file, and json sprite sheet info file.
 
 ### Configuration
 Inside the *love.load( )* function you will be able to find some parameters you can modify to your liking.
 
  - *intShapes*, the amount of shapes you want to generate, please take something that has a round square root (so generally speaking anything that is a second power). This requirement might be removed or tweaked later.
- - *arrPolygon* a table consisting 2 integers *intRadius* and *intThickness* (should be self explanatory).
+ - *intPadding*, the amount of space between each image/polygon. `intPadding + intDiameter = tileSize`
+ - *arrPolygon* a table consisting 2 integers *intDiameter* and *intThickness* (should be self explanatory).
  - *intPolygonSegments* is the amount of "segments" used to draw the polygons, it is advised to set this higher than 3 and lower than *math.huge( )*. I often use 360 for the best resulsts.
  - *intInnerPolygonSegments* usually the same as *intPolygonSegments*, will be deprecated in future releases.
  - *boolImage* if this is TRUE then the script will check for an image named logo.png inside the folder where the main.lua script is located. This image will then be used as a base/shape instead of making polygons.
- - *intAspectModifier* this integer can be set up "upscale" the result. Keep in mind that this modifier will multiply to the default **1024x1024** so an *intAspectModifier* of 2 makes the end result 2048x2048. This can be used to get slightly better results in the editing afterwards.
+ - *intAspectModifier* this integer can be set up "upscale" the result. Keep in mind that this modifier will multiply to the default **1024x1024** so an *intAspectModifier* of 2 makes the end result 2048x2048. This can be used to get slightly better results if editing afterwards. Note that the generated config files will follow this value and are not automatically scaled down to 1024x1024. You may need to tweak their values after uploading to Roblox.
 
 
 ### **Notes**
-This supports transparent backgrounds and transparent images. The generated images will have transparent background, and image transparency will show.
+This supports transparent backgrounds and transparent images. The generated images will have transparent backgrounds, and image transparency will show.
 
 The end result will stay "pixelated" because we are limited to 1024x1024 images on ROBLOX, there is nothing I can do about that.
 
 ----------
 
-*The following examples are using an image with the dimension of **1024x1024**, most images that are bigger than this will be down scaled to this.*
+*The following example is using an image with the dimension of **1024x1024**, most images that are bigger than this will be down scaled to this.*
 
-### ROBLOX Example (Polygonal)
-
-```lua    
---[[ Insert this in a localscript in an ImageLabel/ImageButton ]]--
---[[ Touch this ]]--
-local intShapes					=	25 ;
-local intShapesPerRow			=	5 ;
-local intBox					=	64 * 2.5 ;			--This equals to arrPolygon.intRadius * 2.5
-local intBoxOffset				=	64 * 3 ;			--This equals to arrPolygon.intRadius * 3
-local intOffset 				=	64 * ( 3 / 4 ) ;	--This equals to arrPolygon.intRadius * ( 3 / 4 )
-
---[[ Do not touch this ]]--
-local intCurrent				=	0 ;
-local vec2New					=	Vector2.new ;
-local floor						=	math.floor ;
-
-script.Parent.ImageRectSize		=	vec2New( intBox, intBox ) ;
-
-while ( wait( .1 ) ) do
-script.Parent.ImageRectOffset=	vec2New( intOffset + ( ( intCurrent % intShapesPerRow ) * intBoxOffset ), intOffset + ( floor( intCurrent / intImagesPerRow ) * intBoxOffset ) ) ;
-intCurrent 					=	( intCurrent >= intShapes ) and 0 or intCurrent + 1 ;
-end
-```
-
-
-### ROBLOX Example (Image)
+### ROBLOX Example
+*Works with both image mode and polygon mode*
 
 ```lua
---[[ Insert this in a localscript in an ImageLabel/ImageButton ]]--
+--[[ Insert this in a LocalScript in an ImageLabel/ImageButton. Insert ConfigReader into the LocalScript as a ModuleScript. ]]--
 --[[ Touch this ]]--
-local intShapes					=	25 ;
-local intShapesPerRow			=	5 ;
-local intBox					=	64 * 1.5 ;			--This equals to arrPolygon.intRadius * 1.5
-local intBoxOffset				=	64 * 3 ;			--This equals to arrPolygon.intRadius * 3
-local intOffset 				=	64 * ( 6 / 4 ) ;	--This equals to arrPolygon.intRadius * ( 6 / 4 )
+local ConfigReader				=	require(script.ConfigReader) ;
+
+local config					=	{diameter=120,padding=4,count=64,size=1024} ; -- The generated lua export file contents
 
 --[[ Do not touch this ]]--
 local intCurrent				=	0 ;
 local vec2New					=	Vector2.new ;
-local floor						=	math.floor ;
 
-script.Parent.ImageRectSize		=	vec2New( intBox, intBox ) ;
+script.Parent.ImageRectSize		=	vec2New( ConfigReader.GetSize( config ) ) ;
 
 while ( wait( .1 ) ) do
-script.Parent.ImageRectOffset=	vec2New( intOffset + ( ( intCurrent % intShapesPerRow ) * intBoxOffset ), intOffset + ( floor( intCurrent / intImagesPerRow ) * intBoxOffset ) ) ;
-intCurrent 					=	( intCurrent >= intShapes ) and 0 or intCurrent + 1 ;
+script.Parent.ImageRectOffset	=	vec2New( ConfigReader.GetOffset( config, intCurrent ) ) ;
+intCurrent 						=	intCurrent + 1 ;
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Inside the *love.load( )* function you will be able to find some parameters you 
 ### **Notes**
 This supports transparent backgrounds and transparent images. The generated images will have transparent backgrounds, and image transparency will show.
 
-The end result will stay "pixelated" because we are limited to 1024x1024 images on ROBLOX, there is nothing I can do about that.
+This uses anti-aliasing to keep edges smooth, but the end result will stay "pixelated" because we are limited to 1024x1024 images on ROBLOX.
 
 ----------
 

--- a/main.lua
+++ b/main.lua
@@ -40,13 +40,10 @@ function love.load( )
 
 	love.filesystem.setIdentity( 'CircleSpritesheet' ) ;
 
-	Canvas = Graphics.newCanvas( 1024 * intAspectModifier, 1024 * intAspectModifier, "rgba8", 8 ) ;
+	Canvas = Graphics.newCanvas( 1024 * intAspectModifier, 1024 * intAspectModifier, "rgba8", 16 ) ;
 
 	Graphics.setBackgroundColor( rgbaBg ) ;
 	Graphics.setColor( rgbaI ) ;
-
-	Graphics.setCanvas( Canvas ) ;
-	Graphics.setBackgroundColor( rgbaBg ) ;
 
 	intShapes 			=	intShapes - 1 ;
 
@@ -82,11 +79,14 @@ end
 
 --[[ Using this for smoother drawing ]]--
 function love.conf( t )
-    t.window.fsaa 			= 	8 ;
+    t.window.msaa 			= 	16 ;
 end
 
 --[[ Do not touch ]]--
 function love.draw( )
+	Graphics.setCanvas( Canvas ) ;
+	Graphics.setBackgroundColor( rgbaBg ) ;
+
 	if ( boolImage ) then
 		for i = 1, intShapes do
 			DrawImage( ( ( intImageWidth + intPadding * 2 ) * ( floor( i % intRows ) ) ) + intPadding, ( ( intImageHeight + intPadding * 2 ) * floor( i / intRows ) ) + intPadding, i ) ;

--- a/main.lua
+++ b/main.lua
@@ -40,8 +40,13 @@ function love.load( )
 
 	love.filesystem.setIdentity( 'CircleSpritesheet' ) ;
 
+	Canvas = Graphics.newCanvas( 1024 * intAspectModifier, 1024 * intAspectModifier, "rgba8", 8 ) ;
+
 	Graphics.setBackgroundColor( rgbaBg ) ;
 	Graphics.setColor( rgbaI ) ;
+
+	Graphics.setCanvas( Canvas ) ;
+	Graphics.setBackgroundColor( rgbaBg ) ;
 
 	intShapes 			=	intShapes - 1 ;
 
@@ -91,6 +96,9 @@ function love.draw( )
 			DrawPolygon( ( ( arrPolygon.x + intPadding * 2 ) * ( floor( i % intRows ) ) ) + arrPolygon.x / 2 + intPadding, ( ( arrPolygon.y + intPadding * 2 ) * floor( i / intRows ) ) + arrPolygon.y / 2 + intPadding, i ) ;
 		end
 	end
+
+	Graphics.setCanvas( ) ;
+	Graphics.draw( Canvas );
 
 	local gpScreeenshot 	= 	Graphics.newScreenshot( true ) ;
 	gpScreeenshot:encode( 'png', nameBase..' Image.png' ) ;


### PR DESCRIPTION
This change adds transparency support.

* `newScreenshot( true )` saves a screenshot with transparency.
* Stencils are used to *not draw* in background areas.
  * This replaces the technique of drawing the background color in background areas. That does not work when preserving transparency.

Note: The Atom editor seems to have removed spaces at the end of lines. That was not intentional, but I don't think it's harmful either so I haven't done the work to put them back.

---

This change adds configurable padding support.

* `intPadding` controls the number of pixels between each sprite.
* `intDiameter` has replaced `intRadius`. This feels more natural when trying to make sprites for a specific UI element of a specific size. It is also easier to think about tiling sprites better this way.
* The size of a sprite tile is always `intPadding + intDiameter`. The sprite is always centered in the tile.
* This change makes it easier to pack as many high-quality sprites into a single image as possible.

---

This change adds a helper module and exported configurations that can be plugged into the helper module.

* This changes the output name format such that 'Image' is at the end, with `baseName` before it.
  * This adds `baseName.." Lua.lua"` as a config output
  * This adds `baseName.." JSON.json"` as a config output
* This adds the `ConfigReader.lua` file, intended to be used as a module.
  * `GetOffset( config, number )` takes one of the above configs and returns the top left position of the sprite for `number`, where the "sprite" is the progress circle *not including padding*.
  * `GetSize( config )` takes one of the above configs and returns the size of the progress circle *not including padding*.
* This change makes it easier to programmatically interface with the generated spritesheet.

---

This change adds anti-aliasing.

* Draws to a Canvas first, then draws the Canvas to have edges with anti-aliasing.